### PR TITLE
:bug: issue #11 `spring`を`linear`に差し替え、アイコンのバネのような動きを修正

### DIFF
--- a/1weekPDCA/presentation/BottomBar.swift
+++ b/1weekPDCA/presentation/BottomBar.swift
@@ -63,7 +63,7 @@ struct BottomBar: View {
                                 // response : アニメーションの最高点での跳ね返り度合い
                                 // dampingFraction : アニメーションが収束するまでの時間
                                 // blendDuration : アニメーションが続く時間
-                                withAnimation(.spring(response: 0.05, dampingFraction: 0.05, blendDuration: 0.05)) {
+                                withAnimation(.linear(duration: 0.05)) {
                                             self.isBig = true
                                         }
                             }


### PR DESCRIPTION
## 🎫 課題へのリンク

- issue #11  

## ✨ やったこと

- 原因となっていた`withAnimation`の`spring()`を線型アニメーション`linear()`に編集

## 🚩 やらないこと

- 特になし

## 👍 できるようになること（ユーザ目線）

- アプリ初動のアイコンタップ時、初回だけプルプルする不自然な動作が解消され、ストレスなく利用できるようになった

## 👎 できなくなること（ユーザ目線）

- なし

## ✅ 動作確認

検証環境：iOS16.2 iPhone 14 Pro（simulator）


https://user-images.githubusercontent.com/111550856/218398173-e795a891-9a85-429a-9454-c894df5723da.mov




## 🔀 マージ条件

- [x] セルフレビューに通過すること