### PR TITLE
Feature/issue#22 👍 タスク・Todo削除ボタンを実装

### DIFF
--- a/1weekPDCA/domain/TaskCardManager.swift
+++ b/1weekPDCA/domain/TaskCardManager.swift
@@ -91,51 +91,24 @@ class TaskCardManager: ObservableObject{
     }
     
     // Delete 処理
-    func deleteTask(taskIndex: Int, value: DragGesture.Value, taskCardManager: TaskCardManager) {
-        if value.translation.width < -100 {
-            
-            realmDataBaseManager.realmDeleteTaskCard(
-                taskId: taskCardData[taskIndex].taskId,
-                taskCardManager: taskCardManager)
-            
-            taskCardData.remove(at: taskIndex)
-            
-            print("Swiped left!")
-            
-        } else if value.translation.width > 100 {
-            
-            realmDataBaseManager.realmDeleteTaskCard(
-                taskId: taskCardData[taskIndex].taskId,
-                taskCardManager: taskCardManager)
-            
-            taskCardData.remove(at: taskIndex)
-            
-            print("Swiped right!")
-        }
+    func deleteTask(taskIndex: Int, taskCardManager: TaskCardManager) {
+        
+        realmDataBaseManager.realmDeleteTaskCard(
+            taskId: taskCardData[taskIndex].taskId,
+            taskCardManager: taskCardManager)
+        
+        taskCardData.remove(at: taskIndex)
+        
     }
     
-    func deleteTodo(taskIndex: Int, todoIndex: Int, value: DragGesture.Value, taskCardManager: TaskCardManager) {
+    func deleteTodo(taskIndex: Int, todoIndex: Int, taskCardManager: TaskCardManager) {
         
-        if value.translation.width < -100 {
-            
             realmDataBaseManager.realmDeleteTodoCard(
                 todoId: taskCardData[taskIndex].todoData[todoIndex].todoId,
                 taskCardManager: taskCardManager
             )
             
             taskCardData[taskIndex].todoData.remove(at: todoIndex)
-            
-            print("Swiped left!")
-        } else if value.translation.width > 100 {
-            
-            realmDataBaseManager.realmDeleteTodoCard(
-                todoId: taskCardData[taskIndex].todoData[todoIndex].todoId,
-                taskCardManager: taskCardManager
-            )
-            
-            taskCardData[taskIndex].todoData.remove(at: todoIndex)
-            
-            print("Swiped right!")
-        }
+        
     }
 }

--- a/1weekPDCA/presentation/PlanDo.swift
+++ b/1weekPDCA/presentation/PlanDo.swift
@@ -52,6 +52,7 @@ struct customProgressCircle: View {
                 .stroke(style: StrokeStyle(lineWidth: 5, lineCap: .round, lineJoin: .round))
                 .foregroundColor(colorUtils.getProgressColor(for: circleProgress))
                 .rotationEffect(Angle(degrees: 270.0))
+                .animation(.easeInOut, value: circleProgress) // アニメーションを追加
             
             // 一回り小さな円
             Circle()
@@ -223,7 +224,6 @@ struct TaskCardListView: View {
                         taskCardManager.deleteTask(taskIndex: taskIndex, value: value, taskCardManager: taskCardManager)
                     }
                 )
-                
             }
         }
     }

--- a/1weekPDCA/presentation/PlanDo.swift
+++ b/1weekPDCA/presentation/PlanDo.swift
@@ -124,6 +124,23 @@ struct TaskCardListView: View {
                 CardView {
                     VStack {
                         HStack {
+                            
+                            Spacer()
+                            
+                            Button(action: {
+                                taskCardManager.deleteTask(taskIndex: taskIndex, taskCardManager: taskCardManager)
+                            }) {
+                                Image(systemName: "minus")
+                                    .resizable()
+                                    .frame(width: 15, height: 3)
+                                    .foregroundColor(Color.uiColorGray).opacity(0.5)
+                            }
+                            .shadow(radius: 5)
+                            
+                            
+                        }
+                        
+                        HStack {
                             // 30文字までに制限？
                             TextField(
                                 "task title",
@@ -202,7 +219,7 @@ struct TaskCardListView: View {
                             // スワイプで todo を削除
                             .gesture(DragGesture()
                                 .onEnded { value in
-                                    taskCardManager.deleteTodo(taskIndex: taskIndex, todoIndex: todoIndex, value: value, taskCardManager: taskCardManager)
+                                    taskCardManager.deleteTodo(taskIndex: taskIndex, todoIndex: todoIndex, taskCardManager: taskCardManager)
                                 })
                         }
                         
@@ -221,12 +238,6 @@ struct TaskCardListView: View {
                         }
                     }
                 }
-                // スワイプで task を削除
-                .gesture(DragGesture()
-                    .onEnded { value in
-                        taskCardManager.deleteTask(taskIndex: taskIndex, value: value, taskCardManager: taskCardManager)
-                    }
-                )
             }
         }
     }

--- a/1weekPDCA/presentation/PlanDo.swift
+++ b/1weekPDCA/presentation/PlanDo.swift
@@ -130,10 +130,17 @@ struct TaskCardListView: View {
                             Button(action: {
                                 taskCardManager.deleteTask(taskIndex: taskIndex, taskCardManager: taskCardManager)
                             }) {
-                                Image(systemName: "minus")
-                                    .resizable()
-                                    .frame(width: 15, height: 3)
-                                    .foregroundColor(Color.uiColorGray).opacity(0.5)
+                                
+                                ZStack {
+                                
+                                    Color.clear.frame(width: 20, height: 10)
+                                    
+                                    Image(systemName: "minus")
+                                        .resizable()
+                                        .frame(width: 15, height: 3)
+                                        .foregroundColor(Color.uiColorGray).opacity(0.5)
+                                }
+                                
                             }
                             .shadow(radius: 5)
                             
@@ -216,8 +223,15 @@ struct TaskCardListView: View {
                                         Button(action: {
                                             taskCardManager.deleteTodo(taskIndex: taskIndex, todoIndex: todoIndex, taskCardManager: taskCardManager)
                                         }) {
-                                            Image(systemName: "minus")
-                                                .foregroundColor(Color.uiColorGray).opacity(0.5)
+                                            
+                                            ZStack {
+                                                
+                                                Color.clear.frame(width: 20, height: 10)
+                                                
+                                                Image(systemName: "minus")
+                                                    .foregroundColor(Color.uiColorGray).opacity(0.5)
+                                            }
+                                            
                                         }
                                     }
                                 }

--- a/1weekPDCA/presentation/PlanDo.swift
+++ b/1weekPDCA/presentation/PlanDo.swift
@@ -196,7 +196,7 @@ struct TaskCardListView: View {
                                             
                                             TextField("ToDo", text: $taskCardManager.taskCardData[taskIndex].todoData[todoIndex].todoText, axis: .vertical)
                                                 .textStyle(for: .body, color: .uiColorWhite)
-                                                .frame(width: UIScreen.main.bounds.width / 10 * 6)
+                                                .frame(width: UIScreen.main.bounds.width / 10 * 5)
                                                 .fixedSize(horizontal: false, vertical: true)
                                                 .onChange(
                                                     of: taskCardManager.taskCardData[taskIndex].todoData[todoIndex].todoText,
@@ -212,15 +212,16 @@ struct TaskCardListView: View {
                                             
                                             Color.clear.frame(width:10, height: 4)
                                         }
+                                        
+                                        Button(action: {
+                                            taskCardManager.deleteTodo(taskIndex: taskIndex, todoIndex: todoIndex, taskCardManager: taskCardManager)
+                                        }) {
+                                            Image(systemName: "minus")
+                                                .foregroundColor(Color.uiColorGray).opacity(0.5)
+                                        }
                                     }
                                 }
                             }
-                            
-                            // スワイプで todo を削除
-                            .gesture(DragGesture()
-                                .onEnded { value in
-                                    taskCardManager.deleteTodo(taskIndex: taskIndex, todoIndex: todoIndex, taskCardManager: taskCardManager)
-                                })
                         }
                         
                         HStack {

--- a/1weekPDCA/presentation/PlanDo.swift
+++ b/1weekPDCA/presentation/PlanDo.swift
@@ -299,7 +299,7 @@ struct PlanDoView: View {
                 TaskCardListView().environmentObject(taskCardManager).onAppear(perform: taskCardManager.reloadTaskCardData)
                 
                 // キーボード入力がしやすいように持ち上げ
-                Color.clear.frame(width:15, height: 300)
+                Color.clear.frame(width:15, height: 150)
             }
             
             VStack {

--- a/1weekPDCA/presentation/PlanDo.swift
+++ b/1weekPDCA/presentation/PlanDo.swift
@@ -26,6 +26,8 @@ struct CustomProgressBar: View {
                 
                 Rectangle().frame(width: min(CGFloat(progress) * geometry.size.width, geometry.size.width), height: 10)
                     .foregroundColor(colorUtils.getProgressColor(for: progress))
+                    .animation(.easeInOut, value: progress)
+                
             }.cornerRadius(45.0)
         }
     }

--- a/1weekPDCA/presentation/PlanDo.swift
+++ b/1weekPDCA/presentation/PlanDo.swift
@@ -58,6 +58,7 @@ struct customProgressCircle: View {
             Circle()
                 .fill(colorUtils.getProgressColor(for: circleProgress).opacity(0.5))
                 .frame(width: 35, height: 35)
+                .animation(.easeInOut, value: circleProgress)
         }
     }
 }


### PR DESCRIPTION
## 🎫 課題へのリンク

- issue #22 

## ✨ やったこと

- カード上に「タスク削除ボタン・Todo削除ボタン」を実装し、削除導線を分かりやすくした

## 🚩 やらないこと

- カード削除アニメーションの実装
   ▶︎ Check 画面、Act 画面 実装後に着手（こちらの方が優先度高め）

## 👍 できるようになること（ユーザ目線）

- 画面上に「ボタン」として削除動作を可視化したので、ヘルプマニュアルが無くても削除の仕方が分かりやすくなった

- すワイプ動作を無くしたので、「意図せず隣の画面へスワイプ遷移してしまう」を防ぐ事ができる

## 👎 できなくなること（ユーザ目線）

- 横スワイプによるカード削除動作

## ✅ 動作確認

検証環境：iOS16.4 iPhone14Pro（エミュレータ)

https://user-images.githubusercontent.com/111550856/230718044-6c1589ef-da6f-4fd5-b64a-1bee9923a1cb.mov



## 🔀 マージ条件

- [x] セルフレビューに通過すること
- [x] CI （自動テスト）に通過すること
